### PR TITLE
Adhere to POSIX compliance and best practices

### DIFF
--- a/tests/scripts/check_prepare_integration_test.sh
+++ b/tests/scripts/check_prepare_integration_test.sh
@@ -1,32 +1,42 @@
-#!/bin/bash
+#!/usr/bin/env sh
+
+set -e
+
+# exit and return error message to stderr
+exit_error() {
+    echo "Error: $1" >&2
+    exit 1
+}
 
 integration_test=$1
 test_directory=./tests/docker_tests/$integration_test
 
-# check test exists
-if [ ! -d $test_directory ]; then
-  echo "Can't find integration test $integration_test or it is not a directory!"
-  exit 1
-fi
+# check jq is installed
+command -v jq >/dev/null 2>&1 || exit_error "jq is required but it's not installed."
 
-# check test main file exists
-if [ ! -f $test_directory/run.sh -o ! -x $test_directory/run.sh ]; then
-  echo "Can't find main test file run.sh or it is not executable!"
-  exit 1
+# print usage if no argument was provided
+[ -z "$integration_test" ] && echo "Usage: $0 <dir>" >&2 && exit 1
+
+# check test exists
+[ ! -d "$test_directory" ] && exit_error "Can't find integration test in $integration_test or it is not a directory!"
+
+# check test main file exists and is executable
+if [ ! -x "$test_directory/run.sh" ]; then
+  exit_error "Expected main test file at '$test_directory/run.sh' is missing or not executable"
 fi
 
 # check for setup file
-if [ -f $test_directory/setup.sh -a -x $test_directory/setup.sh ]; then
-  echo "has-setup=true" >> $GITHUB_OUTPUT
+if [ -f "$test_directory/setup.sh" ] && [ -x "$test_directory/setup.sh" ]; then
+  echo "has-setup=true" >> "$GITHUB_OUTPUT"
 fi
 
-#check for teardown file
-if [ -f $test_directory/teardown.sh -a -x $test_directory/teardown.sh ]; then
-  echo "has-teardown=true" >> $GITHUB_OUTPUT
+# check for teardown file
+if [ -f "$test_directory/teardown.sh" ] && [ -x "$test_directory/teardown.sh" ]; then
+  echo "has-teardown=true" >> "$GITHUB_OUTPUT"
 fi
 
-#check for config file
-if [ -f $test_directory/config.json ]; then
-  friendly_name=$(cat $test_directory/config.json | jq ".friendly_name // \"$integration_test\"")
-  echo "friendly_name=$friendly_name" >> $GITHUB_OUTPUT
-fi
+# check for config file
+if [ -f "$test_directory/config.json" ]; then
+  friendly_name=$(jq ".friendly_name // \"$integration_test\"" < "$test_directory/config.json")
+  echo "friendly_name=$friendly_name" >> "$GITHUB_OUTPUT"
+f


### PR DESCRIPTION
Add POSIX compliance and follow current best practices

- Ensure all paths are double quoted to prevent globbing and word splitting.
- Change shebang to use for better portability. On some systems, bash is not installed on /bin/bash (or not at all). Most most linux systems sh defaults to bash nowadays  but there are exceptions. 
- Implement shells 'set -e' to ensure script exits on error.
- Add 'exit_error' function for standardized error handling to stderr instead of stdout.
- Check for 'jq' dependency before execution.
- Remove useless use of cat.
- Improve input argument handling with usage message if no directory was provided.
- Refactor directory and file checks.
- Remove redundant file exists check when checking for executable flag.
- More robust checks for 'setup.sh', 'teardown.sh', and 'config.json'.
- Use command substitution for reading 'friendly_name' from JSON.